### PR TITLE
Updated README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 | ![available](https://github.com/younatics/AppUpdater/blob/master/Images/update_on.gif) | ![unavailable](https://github.com/younatics/AppUpdater/blob/master/Images/update_off.gif) |
 
 ## Requirements
-`PowerMode` is written in Swift 4. Compatible with iOS 9.0+
+`AppUpdater` is written in Swift 4. Compatible with iOS 9.0+
 
 ## Usage
 `AppUpdater.showUpdateAlert()` or use `AppUpdater.showUpdateAlert(isForce: true)` if you want force update. 


### PR DESCRIPTION
Fixed `AppUpdater` is incorrectly referenced as `PowerMode`.